### PR TITLE
Fix maplibre get started

### DIFF
--- a/examples/get-started/maplibre/package.json
+++ b/examples/get-started/maplibre/package.json
@@ -4,7 +4,6 @@
     "build": "vite build"
   },
   "dependencies": {
-    "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "maplibre-gl": "^2.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
It seems the mapbox placeholder is no longer needed?  `npm i` gave me some error until I removed it.  Not sure if anything else needs to be bumped as well?

Thanks for all your hard work!